### PR TITLE
Re-raise instead of exit on tkiniter import error

### DIFF
--- a/src/mouseinfo/__init__.py
+++ b/src/mouseinfo/__init__.py
@@ -195,7 +195,7 @@ if platform.system() == 'Linux':
             ttk = tkinter
             from Tkinter import Event
         except ImportError:
-            sys.exit('NOTE: You must install tkinter on Linux to use MouseInfo. Run the following: sudo apt-get install python-tk python-dev')
+            raise ImportError('You must install tkinter on Linux to use MouseInfo. For Ubuntu Linux, run the following: sudo apt-get install python-tk python-dev')
     else:
         # Running Python 3+:
         try:
@@ -203,7 +203,7 @@ if platform.system() == 'Linux':
             from tkinter import ttk
             from tkinter import Event
         except ImportError:
-            sys.exit('NOTE: You must install tkinter on Linux to use MouseInfo. Run the following: sudo apt-get install python3-tk python3-dev')
+            raise ImportError('You must install tkinter on Linux to use MouseInfo. For Ubuntu Linux, run the following: sudo apt-get install python3-tk python3-dev')
 else:
     # Running Windows or macOS:
     if RUNNING_PYTHON_2:


### PR DESCRIPTION
Exiting on tkinter import failure makes tkinter a hard requirement for
all projects that depend on MouseInfo, most notably pyautogui. Re-raising
allows MouseInfo and its dependencies to be optional, which seems aligned
with pyautogui's intent (see
https://github.com/asweigart/pyautogui/blob/57a98be5fc1c33f077ca499f7836741faf31d463/pyautogui/__init__.py#L240-L261)