### PR TITLE
remove python-xlib3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,8 +32,7 @@ setup(
     # NOTE: Update the python_version info for Pillow as Pillow supports later versions of Python.
     install_requires=['pyobjc-core;platform_system=="Darwin"',
                       'pyobjc;platform_system=="Darwin"',
-                      'python3-Xlib;platform_system=="Linux" and python_version>="3.0"',
-                      'Xlib;platform_system=="Linux" and python_version<"3.0"',
+                      'python-Xlib;platform_system=="Linux"',
                       'pyperclip',
                       'Pillow >= 5.2.0; python_version == "3.7"',
                       'Pillow >= 4.0.0; python_version == "3.6"',


### PR DESCRIPTION
Thanks for `mouseinfo`!

Like https://github.com/asweigart/pyautogui/pull/503, this unifies `python-xlib`, `python3-xlib` and `Xlib` under `python-xlib` which is what seems to be actively maintained.